### PR TITLE
Adapt to Solo5 API changes

### DIFF
--- a/lib/bootvar.ml
+++ b/lib/bootvar.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-external get_cmd_line : unit -> string = "caml_get_cmdline"
+external get_cmd_line : unit -> string = "mirage_solo5_get_cmdline"
 
 let argv () =
   let cmd_line = get_cmd_line () in


### PR DESCRIPTION
This adapts to Solo5 API changes in Solo5/solo5#245,
mirage/mirage-solo5#27.

Minor changes (renaming of C stub) only.

Note that CI for this will not succeed until mirage/mirage-solo5#27 is merged.