### PR TITLE
Port to dune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 _build
 *.install
+*.merlin

--- a/_tags
+++ b/_tags
@@ -1,5 +1,0 @@
-true: bin_annot, safe_string, principal
-true: warn(A-44)
-
-<lib> : include
-<lib/*>: package(lwt parse-argv mirage-solo5)

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name mirage-bootvar-solo5)

--- a/lib/dune
+++ b/lib/dune
@@ -1,0 +1,4 @@
+(library
+  (name bootvar)
+  (public_name mirage-bootvar-solo5)
+  (libraries lwt mirage-solo5 parse-argv))

--- a/lib/mirage-bootvar-solo5.mllib
+++ b/lib/mirage-bootvar-solo5.mllib
@@ -1,1 +1,0 @@
-Bootvar

--- a/mirage-bootvar-solo5.opam
+++ b/mirage-bootvar-solo5.opam
@@ -14,12 +14,12 @@ tags: [
   "org:mirage"
 ]
 build: [
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocamlfind" {build}
-  "ocamlbuild" {build}
-  "topkg" {build}
+  "dune" {build & >= "1.0"}
   "mirage-solo5" {>= "0.3.0"}
   "lwt"
   "parse-argv"

--- a/pkg/META
+++ b/pkg/META
@@ -1,9 +1,0 @@
-description = "Library for reading MirageOS unikernel boot parameters in Solo5"
-version = "%%VERSION_NUM%%"
-requires = "lwt mirage-solo5 parse-argv"
-archive(byte) = "mirage-bootvar-solo5.cma"
-archive(native) = "mirage-bootvar-solo5.cmxa"
-plugin(byte) = "mirage-bootvar-solo5.cma"
-plugin(native) = "mirage-bootvar-solo5.cmxs"
-exists_if = "mirage-bootvar-solo5.cma"
-

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,8 +1,0 @@
-#!/usr/bin/env ocaml
-#use "topfind"
-#require "topkg"
-open Topkg
-
-let () =
-  Pkg.describe "mirage-bootvar-solo5" @@ fun c ->
-  Ok [ Pkg.mllib "lib/mirage-bootvar-solo5.mllib"; ]


### PR DESCRIPTION
Following up https://github.com/mirage/mirage-solo5/issues/41, this PR changes the build system to use `dune`.
cc @mato @g2p 